### PR TITLE
ensureIndex is deprecated since 3.0.0; it's now createIndex

### DIFF
--- a/packages/mongo/collection.js
+++ b/packages/mongo/collection.js
@@ -613,11 +613,11 @@ Mongo.Collection.prototype.upsert = function (selector, modifier,
 
 // We'll actually design an index API later. For now, we just pass through to
 // Mongo's, but make it synchronous.
-Mongo.Collection.prototype._ensureIndex = function (index, options) {
+Mongo.Collection.prototype._createIndex = function (index, options) {
   var self = this;
-  if (!self._collection._ensureIndex)
-    throw new Error("Can only call _ensureIndex on server collections");
-  self._collection._ensureIndex(index, options);
+  if (!self._collection._createIndex)
+    throw new Error("Can only call _createIndex on server collections");
+  self._collection._createIndex(index, options);
 };
 Mongo.Collection.prototype._dropIndex = function (index) {
   var self = this;


### PR DESCRIPTION
src: http://docs.mongodb.org/manual/reference/method/db.collection.ensureIndex/

run into that info, so just in case somebody will eventually miss it, when updating meteor to support mongodb 3.0.0 (referencing to: https://github.com/meteor/meteor/blob/devel/History.md#mongo-driver-and-livequery)